### PR TITLE
use separate bind when using metadata; avoid collision of connections…

### DIFF
--- a/cubes/sql/browser.py
+++ b/cubes/sql/browser.py
@@ -122,7 +122,7 @@ class SQLBrowser(AggregationBrowser):
             self.connectable = store
 
             metadata = kwargs.get("metadata",
-                                  sqlalchemy.MetaData(bind=self.connectable))
+                                  sqlalchemy.MetaData())
 
         # Options
         # -------
@@ -181,7 +181,8 @@ class SQLBrowser(AggregationBrowser):
                                fact=fact_name,
                                joins=joins,
                                schema=naming.schema,
-                               tables=tables)
+                               tables=tables,
+                               connectable=self.connectable)
 
         # Extract hierarchies
         # -------------------

--- a/cubes/sql/query.py
+++ b/cubes/sql/query.py
@@ -332,7 +332,7 @@ class StarSchema(object):
     """
 
     def __init__(self, label, metadata, mappings, fact, fact_key='id',
-                 joins=None, tables=None, schema=None):
+                 joins=None, tables=None, schema=None, connectable=None):
 
         # TODO: expectation is, that the snowlfake is already localized, the
         # owner of the snowflake should generate one snowflake per locale.
@@ -349,6 +349,7 @@ class StarSchema(object):
         self.joins = joins or []
         self.schema = schema
         self.table_expressions = tables or {}
+        self.connectable = connectable
 
         # Cache
         # -----
@@ -525,6 +526,7 @@ class StarSchema(object):
             table = sa.Table(name,
                              self.metadata,
                              autoload=True,
+                             autoload_with=self.connectable,
                              schema=coalesced_schema)
 
         except sa.exc.NoSuchTableError:


### PR DESCRIPTION
This should fix the problems with the threaded deployment of cubes